### PR TITLE
Support docker stop and start

### DIFF
--- a/sshd.sh
+++ b/sshd.sh
@@ -3,18 +3,21 @@
 #
 
 mkdir -m 0700 -p ~/.ssh
-touch ~/.ssh/authorized_keys
-chmod 0600 ~/.ssh/authorized_keys
+[ ! -f ~/.ssh/authorized_keys ] && {
+    touch ~/.ssh/authorized_keys
+    chmod 0600 ~/.ssh/authorized_keys
 
-[ -n "$GH_USER" ] && {
-    echo >&2 "Downloading pubkeys from https://github.com/${GH_USER}.keys ..."
-    wget -qO- https://github.com/${GH_USER}.keys >> ~/.ssh/authorized_keys
+    [ -n "$GH_USER" ] && {
+        echo >&2 "Downloading pubkeys from https://github.com/${GH_USER}.keys ..."
+        wget -qO- https://github.com/${GH_USER}.keys >> ~/.ssh/authorized_keys
+    }
+
+    [ -n "$LP_USER" ] && {
+        echo >&2 "Downloading pubkeys from https://launchpad.net/~${LP_USER}/+sshkeys ..."
+        wget -qO- https://launchpad.net/~${LP_USER}/+sshkeys >> ~/.ssh/authorized_keys
+    }
 }
 
-[ -n "$LP_USER" ] && {
-    echo >&2 "Downloading pubkeys from https://launchpad.net/~${LP_USER}/+sshkeys ..."
-    wget -qO- https://launchpad.net/~${LP_USER}/+sshkeys >> ~/.ssh/authorized_keys
-}
 if [ $# -gt 0 ]; then
     "$@"
 else


### PR DESCRIPTION
When stopping and starting the ssh key would be added again on the same line, making ssh key auth not work anymore

one solution is to add a new line to the authorized_keys file after appending the key, but that would still mean that the same key would be added multiple times upon stop and start.

 this fix only adds the ssh key if the authorized keys is missing (aka first start).
