### PR TITLE
download_and_extract.bat: Remove useless mkdir.

### DIFF
--- a/ISOs/download_and_extract.bat
+++ b/ISOs/download_and_extract.bat
@@ -31,7 +31,6 @@ if not exist Standalone (
     mkdir _Standalone
     start "foo" /wait sdksetup.exe /quiet /features OptionId.WindowsDesktopDebuggers OptionId.WindowsDesktopSoftwareDevelopmentKit /layout _Standalone
     if ERRORLEVEL 1 goto FAIL
-    mkdir Standlone
     rename _Standalone Standalone
 )
 


### PR DESCRIPTION
This was creating a directory `Standlone` (mind the typo), which is not used.